### PR TITLE
[REQ] Remove pytest-optional-tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,8 +11,6 @@ help:
 	@echo "        Install only the testing tools (included in install-dev)"
 	@echo "test"
 	@echo "        Run pytest on test and report coverage"
-	@echo "test-light"
-	@echo "        Run pytest on the light part of test and report coverage"
 	@echo "install-lint"
 	@echo "        Install only the linter tools (included in install-dev)"
 	@echo "black"
@@ -53,12 +51,7 @@ install-dev:
 install-test:
 	@pip install -e ."[test]"
 
-.PHONY: test test-light
-
 test:
-	@pytest -vx --run-optional-tests=expensive --cov=fdpyutils --doctest-modules test fdpyutils
-
-test-light:
 	@pytest -vx --cov=fdpyutils --doctest-modules test fdpyutils
 
 .PHONY: install-lint

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-optional_tests:
-  expensive : Expensive tests that should only be run infrequently

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ test =
     coveralls
     pytest
     pytest-cov
-    pytest-optional-tests
     pdf2image==1.17.0
 
 # Dependencies needed to run the tests (semicolon/line-separated)


### PR DESCRIPTION
It's been a while I ran the CI for this project.
When I did, I encountered errors with `pytest-optional-tests` in Python 3.10.
Since the project does not rely on this package, this PR removes it.